### PR TITLE
Fix GUIComponent encapsulation and GUIController registration

### DIFF
--- a/interfascia/GUIComponent.java
+++ b/interfascia/GUIComponent.java
@@ -30,7 +30,7 @@ package interfascia;
 
 import processing.event.*;
 
-abstract class GUIComponent {
+public abstract class GUIComponent {
 	private int x, y, wid, hgt;
 	private String label;
 	

--- a/resources/build.properties
+++ b/resources/build.properties
@@ -147,7 +147,7 @@ library.prettyVersion=004
 # Only use maxRevision (or minRevision), when your Library is known to 
 # break in a later (or earlier) release. Otherwise, use the default value 0.
 
-compatible.minRevision=0
+compatible.minRevision=246
 compatible.maxRevision=0
 
 

--- a/resources/library.properties
+++ b/resources/library.properties
@@ -55,5 +55,5 @@ prettyVersion = 004
 # https://raw.githubusercontent.com/processing/processing/master/build/shared/revisions.txt
 # Only use maxRevision (or minRevision), when your library is known to
 # break in a later (or earlier) release. Otherwise, use the default value 0.
-minRevision = 0
+minRevision = 246
 maxRevision = 0


### PR DESCRIPTION
Resolves issues brought up in #1 

- Makes `GUIComponent` public instead of package private
- Allows developers to unregister a `GUIController` from its parent `PApplet`